### PR TITLE
PAC Proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkmarx/cx-common-js-client",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "Client for interaction with Checkmarx products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/dto/proxyConfig.ts
+++ b/src/dto/proxyConfig.ts
@@ -1,6 +1,7 @@
 export interface ProxyConfig {
-    proxyHost:string;
-    proxyPort:string | undefined;
-    proxyUser:string | undefined;
-    proxyPass:string | undefined;
+    proxyHost: string;
+    proxyPort: string | undefined;
+    proxyUser: string | undefined;
+    proxyPass: string | undefined;
+    proxyUrl: string | undefined;
 }

--- a/src/services/clients/httpClient.ts
+++ b/src/services/clients/httpClient.ts
@@ -61,31 +61,32 @@ export class HttpClient {
                     this.proxyConfig.proxyUrl = this.proxyConfig.proxyUrl.replace("pac+", "");
                     await this.getProxyContent();
                     let FindProxyForURL = pac(this.proxyContent);
-                    await FindProxyForURL(this.baseUrl).then((res: string) => {
+                    await FindProxyForURL(this.baseUrl,"").then((res) => {
                         this.proxyResult = res;
                         if (this.proxyConfig) {
-                            let splitted: string[];
-                            let proxyBefore: string[];
+                            let splitted;
+                            let proxyBefore;
                             if (this.proxyResult) {
                                 proxyBefore = this.proxyResult.split(";");
                                 this.proxyResult = proxyBefore[0];
                                 splitted = this.proxyResult.split(" ");
-                                if (splitted[0] == "http" || splitted[0] == "HTTP" || splitted[0] == "proxy" || splitted[0] == "PROXY")
+                                if (splitted[0].toUpperCase() == "HTTP" || splitted[0].toUpperCase() == "PROXY")
                                     this.proxyConfig.proxyUrl = 'http://' + splitted[1];
-                                else if (splitted[0] == "HTTPS" || splitted[0] == "https")
+                                else if (splitted[0].toUpperCase() == "HTTPS")
                                     this.proxyConfig.proxyUrl = 'https://' + splitted[1];
-                                else if (splitted[0] == "SOCKS" || splitted[0] == "socks")
+                                else if (splitted[0].toUpperCase() == "SOCKS" )
                                     this.proxyConfig.proxyUrl = 'socks://' + splitted[1];
-                                else if (splitted[0] == "SOCKS4" || splitted[0] == "spcks4")
+                                else if (splitted[0].toUpperCase() == "SOCKS4")
                                     this.proxyConfig.proxyUrl = 'socks4://' + splitted[1];
-                                else if (splitted[0] == "SOCKS5" || splitted[0] == "socks5")
+                                else if (splitted[0].toUpperCase() == "SOCKS5")
                                     this.proxyConfig.proxyUrl = 'socks5://' + splitted[1];
-                                else
+                                else if (splitted[0].toUpperCase() == "DIRECT")
                                     this.proxyConfig.proxyUrl = '';
-                                this.log.info("Proxy URL : "+this.proxyConfig.proxyUrl);
+                                else if (splitted[0].toUpperCase() != "HTTP" || splitted[0].toUpperCase() != "PROXY" || splitted[0].toUpperCase() != "SOCKS" || splitted[0].toUpperCase() != "SOCKS4" || splitted[0].toUpperCase() != "SOCKS5")
+                                    this.log.warning("We Support only http,https,socks,socks4,socks5 please correct ");
+                                this.log.info("Proxy URL : " + this.proxyConfig.proxyUrl);
                             }
                         }
-
                     });
                 }
             }

--- a/src/services/clients/httpClient.ts
+++ b/src/services/clients/httpClient.ts
@@ -47,22 +47,23 @@ export class HttpClient {
     async getProxyContent() {
         try{ 
            require('superagent-proxy')(request);
-           if (this.proxyConfig?.proxyUrl) {
-            await request.get(this.proxyConfig?.proxyUrl)
+           if (this.proxyConfig && this.proxyConfig.proxyUrl) {
+            await request.get(this.proxyConfig.proxyUrl)
                 .accept('json')
                 .then((res: { text: string; }) => {
                     this.proxyContent = res.text;
                 });
         }
         }catch(e){
-            this.log.error(" Pac file is not found or Empty.Hence ignoring the proxy");
+            this.log.error(" Pac file is not found or empty.Hence ignoring the proxy");
             this.proxyConfig=undefined;
         }
     }
+    //**This function is for getting pac proxy resolve 
     async getPacProxyResolve() {
         if (this.proxyConfig && this.proxyConfig.proxyUrl) {
                let urlSplit= this.proxyConfig.proxyUrl.split("/");
-               if( urlSplit[3] !=null && urlSplit.length>=3 ){
+               if( urlSplit[3] !=undefined && urlSplit.length>=3 ){
                    await this.getProxyContent();
                     if(this.proxyContent){
                     let FindProxyForURL = pac(this.proxyContent);
@@ -72,9 +73,9 @@ export class HttpClient {
                             let splitted;
                             let proxyBefore;
                             if (this.proxyResult) {
-                                proxyBefore = this.proxyResult.split(";");//keep in seperate field
+                                proxyBefore = this.proxyResult.split(";");
                                 this.proxyResult = proxyBefore[0];
-                                splitted = this.proxyResult.split(" ");//check for splitted[0] undefined
+                                splitted = this.proxyResult.split(" ");
                                 this.getProxyType(splitted);
                             }
                         }
@@ -87,7 +88,7 @@ export class HttpClient {
        
     }
 
-
+    //If the pac proxy returning diffrent type then checking and adding it to url and forming final url 
     getProxyType(splitted: string[]){
        if (this.proxyConfig && this.proxyConfig.proxyUrl){
         if(splitted[0]){
@@ -96,7 +97,6 @@ export class HttpClient {
             else if (splitted[0].toUpperCase() == "DIRECT"){
                 this.proxyConfig=undefined;
                 this.log.warning("Pac proxy resolution is DIRECT, hence ignoring proxy. ");
-                //logger Pac proxy resolution is DIRECT, hence ignoring proxy 
             }  
             else if (splitted[0].toUpperCase() == "HTTPS")
                 this.proxyConfig.proxyUrl = 'https://' + splitted[1];

--- a/src/services/proxyHelper.ts
+++ b/src/services/proxyHelper.ts
@@ -6,7 +6,7 @@ export class ProxyHelper {
         let protocol;
         let host;
         let proxyURL;
-        if (proxy.proxyUrl != '' && proxy.proxyUrl != null) {
+        if (proxy.proxyUrl != '' && proxy.proxyUrl != undefined) {
             return proxy.proxyUrl;
         }
         if (proxy.proxyHost.startsWith('https://')) {

--- a/src/services/proxyHelper.ts
+++ b/src/services/proxyHelper.ts
@@ -1,27 +1,30 @@
-import {ProxyConfig} from "..";
+import { ProxyConfig } from "..";
 
 export class ProxyHelper {
-    static getFormattedProxy(proxy: ProxyConfig) : string {
+    static getFormattedProxy(proxy: ProxyConfig): string {
         //if host begins with http:\\ or https:\\ cut and save into var, and get the host ready
         let protocol;
         let host;
         let proxyURL;
-        if(proxy.proxyHost.startsWith('https://')){
-            protocol ='https://';
-            host = proxy.proxyHost.substring(8,proxy.proxyHost.length);
-        }else if(proxy.proxyHost.startsWith('http://')){
-            protocol ='http://';
-            host = proxy.proxyHost.substring(7,proxy.proxyHost.length);
-        }else{
+        if (proxy.proxyUrl != '' && proxy.proxyUrl != null) {
+            return proxy.proxyUrl;
+        }
+        if (proxy.proxyHost.startsWith('https://')) {
+            protocol = 'https://';
+            host = proxy.proxyHost.substring(8, proxy.proxyHost.length);
+        } else if (proxy.proxyHost.startsWith('http://')) {
+            protocol = 'http://';
+            host = proxy.proxyHost.substring(7, proxy.proxyHost.length);
+        } else {
             protocol = 'http://';
             host = proxy.proxyHost;
         }
         //build proxy string with format protocol:\\username:password@url:port
-        if(proxy.proxyUser != '' && proxy.proxyPass != ''){
+        if (proxy.proxyUser != '' && proxy.proxyPass != '') {
             proxyURL = `${protocol}${proxy.proxyUser}:${proxy.proxyPass}@${host}`;
-        }else{
+        } else {
             //if no authentication protocol:\\url:port
-            proxyURL =`${protocol}${host}`;
+            proxyURL = `${protocol}${host}`;
         }
         return proxyURL;
     }


### PR DESCRIPTION
This commit contains PAC proxy support. Client application need to pass proxyconfig.proxyUrl which can be standard http proxy URL or PAC proxy URL.