### PR TITLE
Set presetId to 0 for Project Default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkmarx/cx-common-js-client",
-  "version": "0.1.67",
+  "version": "0.1.69",
   "description": "Client for interaction with Checkmarx products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/dto/proxyConfig.ts
+++ b/src/dto/proxyConfig.ts
@@ -4,6 +4,7 @@ export interface ProxyConfig {
     proxyUser: string | undefined;
     proxyPass: string | undefined;
     proxyUrl: string | undefined;
+    //Placeholder to carry sast,sca proxy urls from plugin to common client. Not used inside httpclient
     sastProxyUrl: string | undefined;
     scaProxyUrl: string | undefined;
     resolvedProxyUrl: string | undefined;

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -565,7 +565,12 @@ Scan results location:  ${result.sastScanResultsLink}
             this.presetId = this.sastConfig.presetId;
         }
         else {
+            if(this.sastConfig.presetName=='Project Default'){
+                this.presetId = 0;
+            }
+            else{
             this.presetId = await this.sastClient.getPresetIdByName(this.sastConfig.presetName);
+            }
         }
 
         if (this.sastConfig.teamId) {

--- a/src/services/clients/scaClient.ts
+++ b/src/services/clients/scaClient.ts
@@ -401,11 +401,22 @@ export class ScaClient {
         this.log.debug(`Sending PUT request to ${uploadUrl}`);
         const child_process = require('child_process');
         let command;
-        if ( this.scanConfig.enableProxy && this.proxyConfig && this.proxyConfig.scaProxyUrl) {
-            let proxyUrl=ProxyHelper.getFormattedProxy(this.proxyConfig);
-            command = `curl -x ${proxyUrl} -X PUT -L "${uploadUrl}" -H "Content-Type:" -T "${file}"`;
+        if (this.scanConfig.enableProxy) {
+            this.log.info(`scanConfig.enableProxy is TRUE`);
+        }
+        if (this.proxyConfig){
+            this.log.info(`proxyConfig is TRUE`);
+            this.log.info(`SCA proxy URL: ` + this.proxyConfig.proxyUrl);
+        }
+        if (this.proxyConfig.proxyUrl){
+            this.log.info(`proxyConfig.proxyUrl is TRUE`);
+        }
+        //proxyConfig is instance of scaProxyConfig so proxyUrl set to proxyConfig proxy url 
+        if ( this.scanConfig.enableProxy && this.proxyConfig && this.proxyConfig.proxyUrl) {
+            let proxyUrl = this.proxyConfig.proxyUrl;
+            command = `curl -x ${proxyUrl} -X PUT -L "${uploadUrl}" -H "Content-Type:" -T "${file}" --ssl-no-revoke`;
         } else {
-            command = `curl -X PUT -L "${uploadUrl}" -H "Content-Type:" -T "${file}"`;
+            command = `curl -X PUT -L "${uploadUrl}" -H "Content-Type:" -T "${file}" --ssl-no-revoke`;
         }
         child_process.execSync(command, { stdio: 'pipe' });
     }


### PR DESCRIPTION
To allow to set preset = 0 so the scan will use whatever preset is set up for the Project.

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct]https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
