### PR TITLE
Sca scan timeout and SAST scan cancellation from server and fixing of incorrect incremental and vulnerability threshold logs

### DIFF
--- a/src/dto/sca/scaConfig.ts
+++ b/src/dto/sca/scaConfig.ts
@@ -32,4 +32,5 @@ export interface ScaConfig {
     isEnableScaResolver: boolean ;
     pathToScaResolver: string;
     scaResolverAddParameters: string;
+    scaScanTimeoutInMinutes?: number;
 }

--- a/src/services/clients/sastClient.ts
+++ b/src/services/clients/sastClient.ts
@@ -17,6 +17,7 @@ export class SastClient {
     private readonly stopwatch = new Stopwatch();
 
     private scanId: number = 0;
+    public scanStatus: string = '';
 
     constructor(private readonly config: SastConfig,
         private readonly httpClient: HttpClient,
@@ -94,6 +95,7 @@ export class SastClient {
                 this.logWaitingProgress,
                 polling);
         } catch (e) {
+            this.scanStatus = ScanStage.Failed;
             throw Error(`Waiting for CxSAST scan has reached the time limit (${polling.masterTimeoutMinutes} minutes).`);
         }
 
@@ -172,11 +174,26 @@ export class SastClient {
         return new Promise<ScanStatus>((resolve, reject) => {
             this.httpClient.getRequest(`sast/scansQueue/${this.scanId}`)
                 .then((scanStatus: ScanStatus) => {
+                    if (this.scanStatus != ScanStage.Failed) {
                     if (SastClient.isInProgress(scanStatus)) {
                         reject(scanStatus);
                     } else {
                         resolve(scanStatus);
                     }
+                }
+                else {
+                    const request = {                    
+                        status: ScanStage.Canceled                        
+                    };
+                    try {                    
+                    this.log.debug('Updating scan settings.');
+                    this.httpClient.patchRequest(`sast/scansQueue/${this.scanId}`, request);
+                    this.log.debug("SAST scan canceled. (scanId: " + this.scanId + ")");
+                }
+                catch(ex) {
+                    this.log.error("SAST scan can't canceled. (scanId: " + this.scanId + "): " + ex);
+                }
+                }
                 }).catch(err => {
                     const scanStatus: ScanStatus = {
                         stage: { value : ScanStage.Failed },
@@ -214,5 +231,10 @@ export class SastClient {
                 scanStatus.stageDetails !== SastClient.SCAN_COMPLETED_MESSAGE;
         }
         return result;
+    }
+
+    private patchScanSettings(request: ScanStatus) {
+        this.log.info('Updating scan settings.');
+        return this.httpClient.patchRequest(`sast/scansQueue/${this.scanId}`, request);
     }
 }

--- a/src/services/clients/sastClient.ts
+++ b/src/services/clients/sastClient.ts
@@ -124,14 +124,14 @@ export class SastClient {
                     this.log.debug(`Resolved post scan action ID: ${foundCustomTask.id}`);
                     return foundCustomTask.id;
                 } else {
-                    this.log.error(`Could not resolve post scan action ID from name: ${postScanActionName}`);
+                    throw Error(`Could not resolve post scan action ID from name: ${postScanActionName}`);
                 }
             }
         } catch (e) {
             if (e.status == 404) {
                 this.log.error('Post Scan Action name API is not supported.');
             }else{
-                this.log.error(`Could not resolve post scan action ID from name: ${postScanActionName}`);
+                throw Error(`Could not resolve post scan action ID from name: ${postScanActionName}`);
             }
         }
         

--- a/src/services/clients/scaClient.ts
+++ b/src/services/clients/scaClient.ts
@@ -507,7 +507,7 @@ The Build Failed for the Following Reasons:
 
     public async waitForScanResults(result: ScanResults) {
         this.log.info("------------------------------------ Get CxSCA Results -----------------------------------");
-        const waiter: SCAWaiter = new SCAWaiter(this.scanId, this.httpClient, this.stopwatch, this.log);
+        const waiter: SCAWaiter = new SCAWaiter(this.config, this.scanId, this.httpClient, this.stopwatch, this.log);
         await waiter.waitForScanToFinish();
         const scaResults: SCAResults = await this.retrieveScanResults();
         const scaReportResults: ScaReportResults = new ScaReportResults(scaResults, this.config);


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct]https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
1)	PLUG-668 [ADO] Add default Sca time out to ADO plugin. 
2)	PLUG-746 [ADO] Stop SAST scan on scan time out if specified from SAST server. 
3)	PLUG-824 [ADO] incorrect incremental and vulnerability threshold logs. 
4)	PLUG-825 [ADO] Build succeeds for invalid post scan action. 

