### PR TITLE
Added Project and Scan Custom Tags for SCA in ADO plugin

### DIFF
--- a/src/dto/sca/scaConfig.ts
+++ b/src/dto/sca/scaConfig.ts
@@ -27,6 +27,8 @@ export interface ScaConfig {
     configFilePaths:string[];
     envVariables:Map<string, string>;
     scaSastTeam:string;
+    projectCustomTags:string;
+    scanCustomTags:string;
     isExploitable:boolean;
     cacert_chainFilePath: string;
     isEnableScaResolver: boolean ;


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct]https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
**Implementation of Project custom Tag in ADO plugin for SCA**

-     Parse the project tags from config in a map of object.
-    Set the Map of tags in request body and update the project while creating scan.

**Implementation of Scan custom Tag in ADO plugin for SCA**

-     Parse the scan tags from config in a map of object.
-     Set the Map of tags in request body while creating scan.

### References
https://checkmarx.atlassian.net/browse/PLUG-1010

### Testing
**Below Testing scenarios are being covered:** 

**New project created, Neither project custom tags are provided, nor the Scan custom tags are provided:** 
 	Custom tags didn't appear in project as well as scan

**New project created, Both Project and Scan custom tags are provided, both have different values:**
	Project tags appeared in project. Project and Scan tags appeared in Scan.

**New project created, Both Project and Scan custom tags are provided, both have same values:**
	Project tags appeared in project. scan tags appeared in Scan only once.

**New project created, Only project custom tags is provided:** 
	Project Custom tags appeared in both project and scan.

**New project created, Only scan custom tags is provided:** 
	Scan Custom tags appeared in scan.

**An existing project used, Both Project custom tags and scan custom tags are provided. Both have different values. 	Project custom tags have different value than it's previous value:** 
	Newly updated Project Custom tags value appeared in project, Newly updated Project Custom tags and Scan Custom tags appeared in Scan.

**New project created, Both Project and Scan custom tags are provided, both have different values, few tags have incorrect syntax(Not in proper key:value pair. Multiple tags values separated by comma), few custom tags do not meet max length criteria(Each key and value can have 250 max character length):**
		Only valid Custom tags are considered which have proper syntax and meet the max length criteria. Invalid custom tags are ignored and a warning message is printed in logs. Valid Project tags appeared in project. Valid Project and Scan tags appeared in Scan.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
