### PR TITLE
Changes related to result state and plugin name in user agent header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkmarx/cx-common-js-client",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "description": "Client for interaction with Checkmarx products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,22 +38,23 @@
   "dependencies": {
     "archiver": "^3.0.0",
     "dateformat": "^3.0.3",
+    "debug": "^4.3.2",
+    "glob-parent": "^5.1.2",
+    "jwt-decode": "^4.0.0",
+    "lodash": "^4.17.21",
     "micromatch": "^3.1.0",
     "mkdirp": "^0.5.4",
     "parse-ms": "^2.1.0",
     "promise-poller": "^1.9.1",
     "proxy-agent": "^4.0.1",
+    "snapdragon": "^0.12.1",
     "superagent": "^5.1.0",
     "superagent-proxy": "^2.1.0",
     "tmp": "^0.1.0",
     "upath": "^1.2.0",
     "walk": "^2.3.14",
     "xml2js": "^0.4.22",
-    "debug": "^4.3.2",
-    "lodash": "^4.17.21",
-    "glob-parent": "^5.1.2",
-    "y18n": "^4.0.1",
-    "snapdragon": "^0.12.1"
+    "y18n": "^4.0.1"
   },
   "devDependencies": {
     "@types/archiver": "^2.1.3",

--- a/src/dto/apiConstant.ts
+++ b/src/dto/apiConstant.ts
@@ -6,6 +6,7 @@ export class APIConstants  {
 
     public static readonly authorizationEP:string = 'auth/identity/connect/authorize';
     public static readonly accessTokenEP:string = 'auth/identity/connect/token';
+    public static readonly userInfoEP:string = 'auth/identity/connect/userinfo';
     public static readonly responseType:string = 'code';
     public static readonly CLIENT_ID:string  = 'client_id';
     public static readonly SCOPE:string  = 'scope';
@@ -14,5 +15,5 @@ export class APIConstants  {
     public static readonly GRANT_TYPE:string  = 'grant_type';
     public static readonly AUTHORIZATION_CODE:string  = 'authorization_code';
     public static readonly REFRESH_TOKEN:string  = 'refresh_token';
-
+    public static readonly BEARER:string  = 'BEARER';
 }

--- a/src/dto/scanConfig.ts
+++ b/src/dto/scanConfig.ts
@@ -15,4 +15,5 @@ export interface ScanConfig {
     sastConfig?: SastConfig;
     scaConfig?: ScaConfig;
     proxyConfig?: ProxyConfig;
+    version?: string;
 }

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -134,11 +134,11 @@ export class CxClient {
                 sastProxyConfig.proxyUrl = this.proxyConfig.sastProxyUrl != '' ? this.proxyConfig.sastProxyUrl : this.proxyConfig.proxyUrl;
                 sastProxyConfig.sastProxyUrl = '';
                 sastProxyConfig.scaProxyUrl = '';
-                this.httpClient = new HttpClient(baseUrl, this.config.cxOrigin, this.config.cxOriginUrl, this.log, sastProxyConfig, this.sastConfig.cacert_chainFilePath);
+                this.httpClient = new HttpClient(baseUrl, this.config.cxOrigin, this.config.cxOriginUrl, this.log, sastProxyConfig, this.sastConfig.cacert_chainFilePath,this.config.version);
             }
             else 
             {
-                this.httpClient = new HttpClient(baseUrl, this.config.cxOrigin, this.config.cxOriginUrl, this.log, undefined, this.sastConfig.cacert_chainFilePath);
+                this.httpClient = new HttpClient(baseUrl, this.config.cxOrigin, this.config.cxOriginUrl, this.log, undefined, this.sastConfig.cacert_chainFilePath,this.config.version);
             }
             await this.httpClient.getPacProxyResolve();
             await this.httpClient.login(this.sastConfig.username, this.sastConfig.password);
@@ -165,11 +165,11 @@ export class CxClient {
             scaProxyConfig.sastProxyUrl = '';
             scaProxyConfig.scaProxyUrl = '';
             this.log.info("Overriten URL "+this.config.proxyConfig.sastProxyUrl);
-            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.cxOrigin, this.config.cxOriginUrl,this.log, scaProxyConfig, this.scaConfig.cacert_chainFilePath);
+            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.cxOrigin, this.config.cxOriginUrl,this.log, scaProxyConfig, this.scaConfig.cacert_chainFilePath,this.config.version);
         } 
         else 
         {
-            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.cxOrigin, this.config.cxOriginUrl,this.log, undefined, this.scaConfig.cacert_chainFilePath);
+            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.cxOrigin, this.config.cxOriginUrl,this.log, undefined, this.scaConfig.cacert_chainFilePath,this.config.version);
         }
         await scaHttpClient.getPacProxyResolve();
         this.scaClient = new ScaClient(this.scaConfig, this.config.sourceLocation, scaHttpClient, this.log,scaProxyConfig, this.config);


### PR DESCRIPTION
**Changes**
- Added plugin name and plugin version in user agent header api
- Using just decode converted access token to get sast information(Used this at login with username and password)
- While Login with SSO converted AccessToken to get sast information.

**Test Cases**
- Run SCA and SAST scan on both Q1_2024_Integration_branch and master branch
- Compared both  and it shows same vulnarabilities

SAST 
scan with master - https://cxprivatecloud.checkmarx.net/CxWebClient/ViewerMain.aspx?scanId=1024894&ProjectID=2862
scan with integration branch - https://cxprivatecloud.checkmarx.net/CxWebClient/ViewerMain.aspx?scanId=1024895&ProjectID=2863

SCA 
scan with master - https://sca.checkmarx.net/#/projects/89e2defd-42a7-419c-aa31-fac718c1bb2a
scan with integration branch - https://sca.checkmarx.net/#/projects/96bbad7d-c394-427c-aff9-368e9ce01344/overview