### PR TITLE
Changes related to avoid duplicate scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkmarx/cx-common-js-client",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "Client for interaction with Checkmarx products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/clients/sastClient.ts
+++ b/src/services/clients/sastClient.ts
@@ -152,13 +152,10 @@ export class SastClient {
            {
                 if (SastClient.isInProgress(scanStatus)) {
                     return true;
-                } else {
-                    return false;
                 }
             }
-        }else{
-            return false;
         }
+        return false;
      }
  
     private static throwScanError(status: ScanStatus) {


### PR DESCRIPTION
**Changes**
- Resolved issue related to avoid duplicate scan . Ex- When queue contains 2 scan failed and inprogress then it will check only first scan status others they are skipped

Added functionality of avoid duplicate project scans in queue

**Test Case 1**

- Go to checkmarx extension -> settings -> mark Avoid Duplicate Project Scans In Queue as checked
- Create a new Project (Project1) and run a scan
- wait till the scan complete
- Once the scan is completed create new 2 scans one by one (full scan \ incremental scan)
2nd scan will not created -> will get message if 1st scan is in queue -> Project scan is already in progress.

**Test Case 2**

- Go to checkmarx extension -> settings -> mark Avoid Duplicate Project Scans In Queue as unchecked
- Create a new Project (Project2) and run a scan
- wait till the scan complete
- Once the scan completed create new 2 scans one by one (full scan \ incremental scan)
- Both scan created successfully