### PR TITLE
In 9.6 ScanWithSettings V5 is not accepting a zip file if it's a GIT, SVN, TFS or a Perforce project

### DIFF
--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -367,7 +367,7 @@ export class CxClient {
         let isOverrideProjectSettings = false;
         var apiVersionHeader = {};
         if (await this.isScanLevelCustomFieldSupported()) {
-            apiVersionHeader = { 'Content-type': 'application/json;v=1.2' };
+            apiVersionHeader = { 'Content-type': 'application/json;v=1.2' , 'version' : '1.2'};
         }
         isOverrideProjectSettings = this.sastConfig.overrideProjectSettings || this.isNewProject;
         const scanResponse: ScanWithSettingsResponse = await this.httpClient.postMultipartRequest('sast/scanWithSettings',


### PR DESCRIPTION
**Changes** 
In scanwithsettings API version used 1.2.

**Test Cases**
**Test beow cases with 9.4 , 9.5 , 9.6 , 9.6 with HF**

- Open SAST Server -> create new project with git as source control
- wait till scan completes
- run scan with ADO plugin with same project

