### PR TITLE
ADO pipeline plugin synchronous scan to have a retry number parameter to retry the connection to Checkmarx 

### DIFF
--- a/src/dto/sastConfig.ts
+++ b/src/dto/sastConfig.ts
@@ -15,6 +15,7 @@ export interface SastConfig {
     presetName: string;
     presetId?: number;
     scanTimeoutInMinutes?: number;
+    waitTimeForRetryScan?: number;
     enablePolicyViolations: boolean;
     generatePDFReport: boolean;
     vulnerabilityThreshold: boolean;

--- a/src/dto/sca/scaConfig.ts
+++ b/src/dto/sca/scaConfig.ts
@@ -37,4 +37,5 @@ export interface ScaConfig {
     pathToScaResolver: string;
     scaResolverAddParameters: string;
     scaScanTimeoutInMinutes?: number;
+    scaWaitTimeForRetryScan?: number;
 }

--- a/src/services/clients/sastClient.ts
+++ b/src/services/clients/sastClient.ts
@@ -87,6 +87,8 @@ export class SastClient {
             intervalSeconds: ( this.config.waitTimeForRetryScan != undefined && this.config.waitTimeForRetryScan > 0 ? this.config.waitTimeForRetryScan : SastClient.POLLING_INTERVAL_IN_SECONDS)
         };
 
+        this.log.debug('Waiting time before retry SAST scan is: ' + polling.intervalSeconds);
+
         let lastStatus;
         const waiter = new Waiter();
         try {

--- a/src/services/clients/sastClient.ts
+++ b/src/services/clients/sastClient.ts
@@ -84,7 +84,7 @@ export class SastClient {
 
         const polling: PollingSettings = {
             masterTimeoutMinutes: this.config.scanTimeoutInMinutes,
-            intervalSeconds: SastClient.POLLING_INTERVAL_IN_SECONDS
+            intervalSeconds: ( this.config.waitTimeForRetryScan != undefined && this.config.waitTimeForRetryScan > 0 ? this.config.waitTimeForRetryScan : SastClient.POLLING_INTERVAL_IN_SECONDS)
         };
 
         let lastStatus;

--- a/src/services/scaWaiter.ts
+++ b/src/services/scaWaiter.ts
@@ -25,6 +25,7 @@ export class SCAWaiter {
             intervalSeconds: this.config.scaWaitTimeForRetryScan != undefined && this.config.scaWaitTimeForRetryScan > 0 ? this.config.scaWaitTimeForRetryScan :  SCAWaiter.POLLING_INTERVAL_IN_SECONDS
         };
 
+        this.log.debug('Waiting time before retry SCA scan is: ' + polling.intervalSeconds);
         let lastStatus;
         const waiter = new Waiter();
         try {

--- a/src/services/scaWaiter.ts
+++ b/src/services/scaWaiter.ts
@@ -22,7 +22,7 @@ export class SCAWaiter {
 
         const polling: PollingSettings = {
             masterTimeoutMinutes: this.config.scaScanTimeoutInMinutes,
-            intervalSeconds: SCAWaiter.POLLING_INTERVAL_IN_SECONDS
+            intervalSeconds: this.config.scaWaitTimeForRetryScan != undefined && this.config.scaWaitTimeForRetryScan > 0 ? this.config.scaWaitTimeForRetryScan :  SCAWaiter.POLLING_INTERVAL_IN_SECONDS
         };
 
         let lastStatus;


### PR DESCRIPTION
**Changes**
Added 2 configurable parameters waitTimeForRetryScan and scaWaitTimeForRetryScan for SAST and SCA. If user not added values by default it will take time 10 seconds for SAST and 5 second for SAST.

**Test Cases**
**Note** - We cannot reproduce errors so added a debug log to print parameter values

1) Create new/use existing SAST project with Waiting Time Before Retry Scan In Seconds = blank
	Expected - It will take By default value 10 for SAST scan
	Check Debug Log - Waiting time before retry SAST scan is: 10
2) Create new/use existing SAST project with Waiting Time Before Retry Scan In Seconds = invalid value Ex - abcd
	Expected - It will take By default value 10 for SAST scan
	Check Debug Log - Waiting time before retry SAST scan is: 10
3) Create new/use existing SAST project with Waiting Time Before Retry Scan In Seconds = valid value Ex - 60 
	Expected - It will take By default value 60 for SAST scan
	Check Debug Log - Waiting time before retry SAST scan is: 60
4) Create new/use existing SCA project with Waiting Time Before Retry SCA Scan In Seconds = blank
	Expected - It will take By default value 10 for SCA scan
	Check Debug Log - Waiting time before retry SCA scan is: 5
5) Create new/use existing SCA project with Waiting Time Before Retry SCA Scan In Seconds = invalid value Ex - abcd
	Expected - It will take By default value 10 for SCA scan
	Check Debug Log - Waiting time before retry SCA scan is: 5
6) Create new/use existing SCA project with Waiting Time Before Retry SCA Scan In Seconds = valid value Ex - 60 
	Expected - It will take By default value 60 for SCA scan
	Check Debug Log - Waiting time before retry SCA scan is: 60