### PR TITLE
Critical Severity

### DIFF
--- a/src/dto/sastConfig.ts
+++ b/src/dto/sastConfig.ts
@@ -20,6 +20,7 @@ export interface SastConfig {
     vulnerabilityThreshold: boolean;
     failBuildForNewVulnerabilitiesEnabled: boolean;
     failBuildForNewVulnerabilitiesSeverity: string;
+    criticalThreshold?: number;
     highThreshold?: number;
     mediumThreshold?: number;
     lowThreshold?: number;

--- a/src/dto/scanResults.ts
+++ b/src/dto/scanResults.ts
@@ -18,6 +18,7 @@ export class ScanResults {
     scanId = 0;
     thresholdEnabled: boolean = false;
 
+    criticalThreshold: number | undefined;
     highThreshold: number | undefined;
     mediumThreshold: number | undefined;
     lowThreshold: number | undefined;
@@ -40,10 +41,12 @@ export class ScanResults {
     osaViolations = [];
     osaPolicies = [];
     failBuildForNewVulnerabilitiesEnabled: boolean = false;
+    criticalResults = 0;
     highResults = 0;
     mediumResults = 0;
     lowResults = 0;
     infoResults = 0;
+    newCriticalCount = 0;
     newHighCount = 0;
     newMediumCount = 0;
     newLowCount = 0;
@@ -86,6 +89,7 @@ export class ScanResults {
         this.url = sastConfig.serverUrl;
         this.enablePolicyViolations = sastConfig.enablePolicyViolations;
         this.thresholdEnabled = sastConfig.vulnerabilityThreshold;
+        this.criticalThreshold = sastConfig.criticalThreshold;
         this.highThreshold = sastConfig.highThreshold;
         this.mediumThreshold = sastConfig.mediumThreshold;
         this.lowThreshold = sastConfig.lowThreshold;

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -557,6 +557,7 @@ export class CxClient {
 
     private async addStatisticsToScanResults(result: ScanResults) {
         const statistics = await this.sastClient.getScanStatistics(result.scanId);
+        result.criticalResults = statistics.crticalSeverity;
         result.highResults = statistics.highSeverity;
         result.mediumResults = statistics.mediumSeverity;
         result.lowResults = statistics.lowSeverity;
@@ -609,11 +610,13 @@ export class CxClient {
     }
 
     private printStatistics(result: ScanResults) {
+        const newCritical = (result.newCriticalCount > 0  && result.failBuildForNewVulnerabilitiesEnabled) ? " (" + result.newCriticalCount + " new)" : "";
         const newHigh = (result.newHighCount > 0  && result.failBuildForNewVulnerabilitiesEnabled) ? " (" + result.newHighCount + " new)" : "";
         const newMedium = (result.newMediumCount > 0 && result.failBuildForNewVulnerabilitiesEnabled) ? " (" + result.newMediumCount + " new)" : "";
         const newLow = (result.newLowCount > 0 && result.failBuildForNewVulnerabilitiesEnabled) ? " (" + result.newLowCount + " new)" : "";
         const newInfo = (result.newInfoCount > 0 && result.failBuildForNewVulnerabilitiesEnabled) ? " (" + result.newInfoCount + " new)" : "";
         this.log.info(`----------------------------Checkmarx Scan Results(CxSAST):-------------------------------
+Critical severity results: ${result.criticalResults}${newCritical}
 High severity results: ${result.highResults}${newHigh}
 Medium severity results: ${result.mediumResults}${newMedium}
 Low severity results: ${result.lowResults}${newLow}
@@ -649,6 +652,8 @@ Scan results location:  ${result.sastScanResultsLink}
                 if(result.$.FalsePositive === "False" && result.$.Status === "New"){
                     severity = result.$.Severity;
                     switch(severity){
+                        case "Critical":
+                            scanResult.newCriticalCount++;
                         case "High":
                             scanResult.newHighCount++;
                             break;

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -557,7 +557,7 @@ export class CxClient {
 
     private async addStatisticsToScanResults(result: ScanResults) {
         const statistics = await this.sastClient.getScanStatistics(result.scanId);
-        result.criticalResults = statistics.crticalSeverity;
+        result.criticalResults = statistics.criticalSeverity;
         result.highResults = statistics.highSeverity;
         result.mediumResults = statistics.mediumSeverity;
         result.lowResults = statistics.lowSeverity;

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -643,16 +643,31 @@ export class CxClient {
         const newMedium = (result.newMediumCount > 0 && result.failBuildForNewVulnerabilitiesEnabled) ? " (" + result.newMediumCount + " new)" : "";
         const newLow = (result.newLowCount > 0 && result.failBuildForNewVulnerabilitiesEnabled) ? " (" + result.newLowCount + " new)" : "";
         const newInfo = (result.newInfoCount > 0 && result.failBuildForNewVulnerabilitiesEnabled) ? " (" + result.newInfoCount + " new)" : "";
-        this.log.info(`----------------------------Checkmarx Scan Results(CxSAST):-------------------------------
-Critical severity results: ${result.criticalResults}${newCritical}
-High severity results: ${result.highResults}${newHigh}
-Medium severity results: ${result.mediumResults}${newMedium}
-Low severity results: ${result.lowResults}${newLow}
-Info severity results: ${result.infoResults}${newInfo}
+        if(result.criticalResults != undefined)
+        {
+            this.log.info(`----------------------------Checkmarx Scan Results(CxSAST):-------------------------------
+            Critical severity results: ${result.criticalResults}${newCritical}
+            High severity results: ${result.highResults}${newHigh}
+            Medium severity results: ${result.mediumResults}${newMedium}
+            Low severity results: ${result.lowResults}${newLow}
+            Info severity results: ${result.infoResults}${newInfo}
 
-Scan results location:  ${result.sastScanResultsLink}
-------------------------------------------------------------------------------------------
-`);
+            Scan results location:  ${result.sastScanResultsLink}
+            ------------------------------------------------------------------------------------------
+            `);
+        }
+        else
+        {
+            this.log.info(`----------------------------Checkmarx Scan Results(CxSAST):-------------------------------
+            High severity results: ${result.highResults}${newHigh}
+            Medium severity results: ${result.mediumResults}${newMedium}
+            Low severity results: ${result.lowResults}${newLow}
+            Info severity results: ${result.infoResults}${newInfo}
+
+            Scan results location:  ${result.sastScanResultsLink}
+            ------------------------------------------------------------------------------------------
+            `);
+        }
     }
 
     private static toJsonQueries(scanResult: ScanResults, queries: any[]) {

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -57,10 +57,13 @@ export class CxClient {
         result.syncMode = this.config.isSyncMode;
 
         if (config.enableSastScan) {
-            if(!await this.isSASTSupportsCriticalSeverity() && (this.sastConfig.criticalThreshold > 0 || this.sastConfig.failBuildForNewVulnerabilitiesSeverity == 'CRITICAL'))
+            if(!await this.isSASTSupportsCriticalSeverity() && this.sastConfig.vulnerabilityThreshold)
             {
                 this.sastConfig.criticalThreshold = 0;
-                this.sastConfig.failBuildForNewVulnerabilitiesSeverity = '';
+                if(this.sastConfig.failBuildForNewVulnerabilitiesSeverity == "CRITICAL")
+                {
+                    this.sastConfig.failBuildForNewVulnerabilitiesSeverity = '';
+                }
                 this.log.warning('Below SAST 9.7 version does not supports critical severity because of that ignoring critical threshold.');
             }
             result.updateSastDefaultResults(this.sastConfig);

--- a/src/services/scanSummaryEvaluator.ts
+++ b/src/services/scanSummaryEvaluator.ts
@@ -21,6 +21,7 @@ export abstract class ScanSummaryEvaluator {
 
     private static getSastThresholdErrors(scanResult: any, config: any) {
         const result: ThresholdError[] = [];
+        ScanSummaryEvaluator.addThresholdErrors(scanResult.criticalResults, config.criticalThreshold, 'critical', result);
         ScanSummaryEvaluator.addThresholdErrors(scanResult.highResults, config.highThreshold, 'high', result);
         ScanSummaryEvaluator.addThresholdErrors(scanResult.mediumResults, config.mediumThreshold, 'medium', result);
         ScanSummaryEvaluator.addThresholdErrors(scanResult.lowResults, config.lowThreshold, 'low', result);
@@ -83,6 +84,13 @@ export abstract class ScanSummaryEvaluator {
             result.push({
                 severity, 
                 severityCount: scanResult.newHighCount
+            });    
+            severity = "CRITICAL";        
+        }
+        if(severity === "CRITICAL" && scanResult.newCriticalCount > 0){
+            result.push({
+                severity, 
+                severityCount: scanResult.newCriticalCount
             });            
         }
         return result;

--- a/tests/scanSummaryEvaluator.test.ts
+++ b/tests/scanSummaryEvaluator.test.ts
@@ -24,6 +24,7 @@ describe("ScanSummaryEvaluator", function () {
 
     it('should return threshold errors in summary', function () {
         const config = getSastConfig();
+        config.criticalThreshold = 3;
         config.highThreshold = 1;
         config.mediumThreshold = 5;
         config.lowThreshold = 10;
@@ -33,6 +34,7 @@ describe("ScanSummaryEvaluator", function () {
 
         const scanResults = new ScanResults();
         scanResults.updateSastDefaultResults(config);
+        scanResults.criticalResults = 1;
         scanResults.highResults = 3;
         scanResults.mediumResults = 8;
         scanResults.lowResults = 4;
@@ -44,6 +46,7 @@ describe("ScanSummaryEvaluator", function () {
 
     it('should not return threshold errors if all values are below thresholds', function () {
         const config = getSastConfig();
+        config.criticalThreshold = 10;
         config.highThreshold = 10;
         config.mediumThreshold = 15;
         config.lowThreshold = 20;
@@ -53,6 +56,7 @@ describe("ScanSummaryEvaluator", function () {
 
         const scanResults = new ScanResults();
         scanResults.updateSastDefaultResults(config);
+        scanResults.criticalResults = 2;
         scanResults.highResults = 2;
         scanResults.mediumResults = 11;
         scanResults.lowResults = 18;
@@ -65,6 +69,7 @@ describe("ScanSummaryEvaluator", function () {
 
 function getSastConfig(): SastConfig {
     return {
+        criticalThreshold: 0,
         highThreshold: 0,
         lowThreshold: 0,
         mediumThreshold: 0,


### PR DESCRIPTION
**Changes** 
Critical severity feature for ADO plugin is supported.

**Test Cases**
**Note -** Test below cases with SAST 9.7,9.6,9.5 version

**Case 1** 
- Create a new Project with  -> 
    - Enable SAST scan - Enabled
    - Generate CxSAST PDF report - Enabled
    - Enable Dependency Scan = disabled
    - Enable CxSAST Vulnerability Thresholds = disabled 
    - Enable Project's Policy Enforcement = disabled
    
Check below points 
- Critical severity results = 0 / any value(based on scanned project)
- Open build -> Checkmarx -> Check critical vulnerabilities results and graph, click on Download PDF report and check Critical related count and vulnerability details.

**Case 2** 
- Run a scan with existing Project with -> 
   - Enable SAST scan - Enabled
   - Generate CxSAST PDF report - Enabled
   - Enable Dependency Scan = disabled
   - Enable CxSAST Vulnerability Thresholds = disabled 
   - Enable Project's Policy Enforcement = disabled

Check below points 
- Critical severity results = 0 / any value(based on scanned project)
- Open build -> Checkmarx -> Check critical vulnerabilities results and graph, click on Download PDF report and check Critical related count and vulnerability details.
 
 
**Case 3**
- Create a new/existing Project with (build no. 128) -> 
   - Enable SAST scan - Enabled
   - Generate CxSAST PDF report - Enabled
   - Enable Dependency Scan = Enabled
   - Enable CxSAST Vulnerability Thresholds = disabled 
   - Enable Project's Policy Enforcement = disabled
 
Check below points 
- Critical severity results = 0 / any value(based on scanned project)
- Open build -> Checkmarx -> Check critical vulnerabilities results and graph, click on Download PDF report and check Critical related count and vulnerability details.
 
 
**Case 4**
- Create a new/existing Project with (build no. 129) -> 
   - Enable SAST scan - Enabled
   - Generate CxSAST PDF report - Enabled
   - Enable Dependency Scan = disabled
   - Enable CxSAST Vulnerability Thresholds = disabled 
   - Enable Project's Policy Enforcement = disabled
 
Check below points 
- Critical severity results = 0 / any value(based on scanned project)
- Open build -> Checkmarx -> Check critical vulnerabilities results and graph, click on Download PDF report and check Critical related count and vulnerability details.
 
 
**Case 5**
- Create a new/existing Project with (build no. 129) -> 
   - Enable SAST scan - Enabled
   - Generate CxSAST PDF report - Enabled
   - Enable Dependency Scan = disabled
   - Enable CxSAST Vulnerability Thresholds = Enabled 
   - Fail the build for new SAST vulnerabilities = disabled 
   - Add critical, high , medium, low threshold
   - Enable Project's Policy Enforcement = disabled
 
Check below points 
- build will may fail/success with error messages like
	a. SAST critical severity results are above threshold. Results: 93. Threshold: 5
	b. SAST high severity results are above threshold. Results: 29. Threshold: 3
	c. SAST medium severity results are above threshold. Results: 179. Threshold: 2
	d. SAST low severity results are above threshold. Results: 213. Threshold: 1
- Critical severity results = 0 / any value(based on scanned project)
- Open build -> Checkmarx -> Check critical vulnerabilities results and graph, click on Download PDF report and check Critical related count and vulnerability details.
 
**Case 6**
- Create a new/existing Project with (build no. 129) -> 
   - Enable SAST scan - Enabled
   - Generate CxSAST PDF report - Enabled
   - Enable Dependency Scan = Disabled
   - Enable CxSAST Vulnerability Thresholds = Enabled 
   - Fail the build for new SAST vulnerabilities = Enabled
   - Add critical, high , medium, low threshold
   - Enable Project's Policy Enforcement = disabled
 
Check below points 
- build will may fail/success with error messages like
	a. SAST critical severity results are above threshold. Results: 93. Threshold: 5
	b. SAST high severity results are above threshold. Results: 29. Threshold: 3
	c. SAST medium severity results are above threshold. Results: 179. Threshold: 2
	d. SAST low severity results are above threshold. Results: 213. Threshold: 1
- Critical severity results = 0 / any value(based on scanned project)
- Open build -> Checkmarx -> Check critical vulnerabilities results and graph, click on Download PDF report and check Critical related count and vulnerability details.
 
 
**Case 7**
- Create a new/existing Project with (build no. 129) -> 
   - Enable SAST scan - Enabled
   - Generate CxSAST PDF report - Enabled
   - Enable Dependency Scan = Disabled
   - Enable CxSAST Vulnerability Thresholds = Enabled 
   - Fail the build for new SAST vulnerabilities = Disabled
   - Add critical, high , medium, low threshold
   - Enable Project's Policy Enforcement = Enabled
 
Check below points 
- build will may fail/success with error messages like
	a. Project policy status: violated
- Critical severity results = 0 / any value(based on scanned project)
- Open build -> Checkmarx -> Check critical vulnerabilities results and graph, click on Download PDF report and check Critical related count and vulnerability details.
 
