### PR TITLE
Plug 1969 - if we given existing project name and SAST branching enabled show error message.

### DIFF
--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -345,6 +345,10 @@ export class CxClient {
         if (projectId) {
             this.log.debug(`Resolved project ID: ${projectId}`);
             this.isNewProject = false;
+            if (this.sastConfig.enableSastBranching)
+            {
+                throw Error(`Project with name ${this.config.projectName} is already exists. Cannot create branched project if project name already exists.`);
+            }
         } else {
             this.log.info('Project not found, creating a new one.');
             if (this.sastConfig.denyProject) 

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -347,7 +347,7 @@ export class CxClient {
             this.isNewProject = false;
             if (this.sastConfig.enableSastBranching)
             {
-                throw Error(`Project with name ${this.config.projectName} is already exists. Cannot create branched project if project name already exists.`);
+                throw Error(`Project with name ${this.config.projectName} is already exists. Cannot create branched project as project name already exists.`);
             }
         } else {
             this.log.info('Project not found, creating a new one.');


### PR DESCRIPTION
Test Case
- If project name already exists and sast branching enabled then pipeline will fail with error (**Scan cannot be completed. Project with name RP-Test-02 is already exists. Cannot create branched project if project name already exists.**)
- If Master Branch Project name is not exists then pipeline will fail with error (**Scan cannot be completed. Master branch project does not exist: RP-Test-07**)
- If Master Branch Project name and Project Name both are same and if its exists then pipeline will fail with error (**Project name(abc) and master branch project name(abc) should not be same.**)