### PR TITLE
resolved bug PLUG-1970

### DIFF
--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -57,6 +57,8 @@ export class CxClient {
         result.syncMode = this.config.isSyncMode;
 
         if (config.enableSastScan) {
+            this.log.info('Initializing Cx client');
+            await this.initClients(httpClient);
             if(!await this.isSASTSupportsCriticalSeverity() && this.sastConfig.vulnerabilityThreshold)
             {
                 this.sastConfig.criticalThreshold = 0;
@@ -67,8 +69,6 @@ export class CxClient {
                 this.log.warning('SAST 9.6 and lower version does not supports critical severity because of that ignoring critical threshold.');
             }
             result.updateSastDefaultResults(this.sastConfig);
-            this.log.info('Initializing Cx client');
-            await this.initClients(httpClient);
             await this.initDynamicFields();
 
             if(this.sastConfig.avoidDuplicateProjectScans)


### PR DESCRIPTION
**Test Cases**
1. If using Sast 9.7 and trigger scan then it should not show the “##[warning]SAST 9.6 and lower version does not supports critical severity because of that ignoring critical threshold.“ warning message in logs.
2. When configure pipeline with enable threshold and trigger scan then  it should not show the “Checkmarx server version is lower than 9.0.“ message in logs for Sast 9.4,9.5,9.6,9.7.
3. if configure pipeline and enable sast threshold and trigger scan with sast 9.7 to check critical severity then scan should be successfull.
4. If configure pipeline and given threshold as 500 and trigger scan then scan getting failed. so whatever we put value in critical severity vulnerability threshold it should take same value for threshold check.