### PR TITLE
Critical -SCA changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkmarx/cx-common-js-client",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "description": "Client for interaction with Checkmarx products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/dto/sca/report/package.ts
+++ b/src/dto/sca/report/package.ts
@@ -13,6 +13,7 @@ export class Package {
      */
     private _matchType: string = '';
 
+    private _criticalVulnerabilityCount: number = 0;
     private _highVulnerabilityCount: number = 0;
     private _mediumVulnerabilityCount: number = 0;
     private _lowVulnerabilityCount: number = 0;
@@ -70,6 +71,14 @@ export class Package {
 
     public set matchType(value: string) {
         this._matchType = value;
+    }
+
+    public get criticalVulnerabilityCount(): number {
+        return this._criticalVulnerabilityCount;
+    }
+
+    public set criticalVulnerabilityCount(value: number) {
+        this._criticalVulnerabilityCount = value;
     }
 
     public get highVulnerabilityCount(): number {

--- a/src/dto/sca/report/packageSeverity.ts
+++ b/src/dto/sca/report/packageSeverity.ts
@@ -5,5 +5,6 @@ export enum PackageSeverity {
     NONE = "NONE",
     LOW = "LOW",
     MEDIUM = "MEDIUM",
-    HIGH = "HIGH"
+    HIGH = "HIGH",
+    CRITICAL = "CRITICAL"
 }

--- a/src/dto/sca/report/scaSummaryResults.ts
+++ b/src/dto/sca/report/scaSummaryResults.ts
@@ -1,5 +1,6 @@
 export class ScaSummaryResults {
     private _riskReportId: string = '';
+    private _criticalVulnerabilityCount: number = 0;
     private _highVulnerabilityCount: number = 0;
     private _mediumVulnerabilityCount: number = 0;
     private _lowVulnerabilityCount: number = 0;
@@ -15,6 +16,14 @@ export class ScaSummaryResults {
 
     public set riskReportId(value: string) {
         this._riskReportId = value;
+    }
+
+    public get criticalVulnerabilityCount(): number {
+        return this._criticalVulnerabilityCount;
+    }
+
+    public set criticalVulnerabilityCount(value: number) {
+        this._criticalVulnerabilityCount = value;
     }
 
     public get highVulnerabilityCount(): number {

--- a/src/dto/sca/report/severity.ts
+++ b/src/dto/sca/report/severity.ts
@@ -1,5 +1,6 @@
 export enum Severity {
     LOW = "Low",
     MEDIUM = "Medium",
-    HIGH = "High"
+    HIGH = "High",
+    CRITICAL = "Critical"
 }

--- a/src/dto/sca/scaConfig.ts
+++ b/src/dto/sca/scaConfig.ts
@@ -15,6 +15,7 @@ export interface ScaConfig {
     dependencyFileExtension: string;
     dependencyFolderExclusion: string;
     vulnerabilityThreshold: boolean;
+    criticalThreshold?: number;
     highThreshold?: number;
     mediumThreshold?: number;
     lowThreshold?: number;

--- a/src/dto/sca/scaReportResults.ts
+++ b/src/dto/sca/scaReportResults.ts
@@ -8,6 +8,7 @@ import { ScaConfig } from './scaConfig';
 
 export class ScaReportResults {
     private _resultReady: boolean = false;
+    private _criticalVulnerability: number = 0;
     private _highVulnerability: number = 0;
     private _mediumVulnerability: number = 0;
     private _lowVulnerability: number = 0;
@@ -16,6 +17,7 @@ export class ScaReportResults {
     private _nonVulnerableLibraries: number = 0;
     private _scanStartTime: string = '';
     private _scanEndTime: string = '';
+    private _dependencyCriticalCVEReportTable: CveReportTableRow[] = [];
     private _dependencyHighCVEReportTable: CveReportTableRow[] = [];
     private _dependencyMediumCVEReportTable: CveReportTableRow[] = [];
     private _dependencyLowCVEReportTable: CveReportTableRow[] = [];
@@ -23,6 +25,7 @@ export class ScaReportResults {
     private _packages: Package[] = [];
     private _summary: ScaSummaryResults | any;
     private _vulnerabilityThreshold: boolean = false;
+    private _criticalThreshold?: number;
     private _highThreshold?: number;
     private _mediumThreshold?: number;
     private _lowThreshold?: number;
@@ -30,6 +33,7 @@ export class ScaReportResults {
     constructor(scaResults: SCAResults, scaConfig: ScaConfig) {
         if (scaConfig) {
             this._vulnerabilityThreshold = scaConfig.vulnerabilityThreshold;
+            this._criticalThreshold = scaConfig.criticalThreshold;
             this._highThreshold = scaConfig.highThreshold;
             this._mediumThreshold = scaConfig.mediumThreshold;
             this._lowThreshold = scaConfig.lowThreshold;
@@ -42,6 +46,7 @@ export class ScaReportResults {
             this._summary = scaResults.summary;
 
             if (scaResults.summary) {
+                this._criticalVulnerability = scaResults.summary.criticalVulnerabilityCount;
                 this._highVulnerability = scaResults.summary.highVulnerabilityCount;
                 this._mediumVulnerability = scaResults.summary.mediumVulnerabilityCount;
                 this._lowVulnerability = scaResults.summary.lowVulnerabilityCount;
@@ -60,7 +65,8 @@ export class ScaReportResults {
         let sum: number;
         (this._packages || []).forEach(pckg => {
             if (pckg) {
-                sum = pckg.highVulnerabilityCount +
+                sum = pckg.criticalVulnerabilityCount +
+                    pckg.highVulnerabilityCount +
                     pckg.mediumVulnerabilityCount +
                     pckg.lowVulnerabilityCount;
                 if (sum === 0) {
@@ -87,6 +93,9 @@ export class ScaReportResults {
                 else if (finding.severity === Severity.HIGH) {
                     this._dependencyHighCVEReportTable.push(row);
                 }
+                else if (finding.severity === Severity.CRITICAL) {
+                    this._dependencyCriticalCVEReportTable.push(row);
+                }
             }
         });
     }
@@ -97,6 +106,14 @@ export class ScaReportResults {
 
     public set resultReady(value: boolean) {
         this._resultReady = value;
+    }
+
+    public get criticalVulnerability(): number {
+        return this._criticalVulnerability;
+    }
+
+    public set criticalVulnerability(value: number) {
+        this._criticalVulnerability = value;
     }
 
     public get highVulnerability(): number {
@@ -171,6 +188,14 @@ export class ScaReportResults {
         this._totalLibraries = value;
     }
 
+    public get dependencyCriticalCVEReportTable(): CveReportTableRow[] {
+        return this._dependencyCriticalCVEReportTable;
+    }
+
+    public set dependencyCriticalCVEReportTable(value: CveReportTableRow[]) {
+        this._dependencyCriticalCVEReportTable = value;
+    }
+
     public get dependencyHighCVEReportTable(): CveReportTableRow[] {
         return this._dependencyHighCVEReportTable;
     }
@@ -217,6 +242,14 @@ export class ScaReportResults {
 
     public set vulnerabilityThreshold(value: boolean) {
         this._vulnerabilityThreshold = value;
+    }
+
+    public get criticalThreshold(): number | undefined {
+        return this._criticalThreshold;
+    }
+
+    public set criticalThreshold(value: number | undefined) {
+        this._criticalThreshold = value;
     }
 
     public get highThreshold(): number | undefined {

--- a/src/dto/scanResults.ts
+++ b/src/dto/scanResults.ts
@@ -27,6 +27,7 @@ export class ScanResults {
     osaScanId: string | null = null;
     osaProjectSummaryLink: string | null = null;
     osaThresholdEnabled = false;
+    osaCriticalThreshold = 0;
     osaHighThreshold = 0;
     osaMediumThreshold = 0;
     osaLowThreshold = 0;
@@ -78,6 +79,7 @@ export class ScanResults {
     queryList = '';
     osaStartTime = '';  // E.g. "2019-10-27T12:22:50.223"
     osaEndTime = '';
+    osaCriticalResults = 0;
     osaHighResults = 0;
     osaMediumResults = 0;
     osaLowResults = 0;

--- a/src/services/clients/scaClient.ts
+++ b/src/services/clients/scaClient.ts
@@ -539,6 +539,7 @@ The Build Failed for the Following Reasons:
         await this.printPolicyEvaluation(scaResults.scaPolicyViolation, this.config.scaEnablePolicyViolations);
         await this.determinePolicyViolation(scaResults);
         const vulResults = {
+            criticalResults:scaReportResults.criticalVulnerability,
             highResults: scaReportResults.highVulnerability,
             mediumResults: scaReportResults.mediumVulnerability,
             lowResults: scaReportResults.lowVulnerability
@@ -662,6 +663,7 @@ The Build Failed for the Following Reasons:
         this.log.info("\n----CxSCA risk report summary----");
         this.log.info("Created on: " + summary.createdOn);
         this.log.info("Direct packages: " + summary.directPackages);
+        this.log.info("Critical vulnerabilities: " + summary.criticalVulnerabilityCount);
         this.log.info("High vulnerabilities: " + summary.highVulnerabilityCount);
         this.log.info("Medium vulnerabilities: " + summary.mediumVulnerabilityCount);
         this.log.info("Low vulnerabilities: " + summary.lowVulnerabilityCount);


### PR DESCRIPTION
**Test Cases**

Case 1
- Create new project with Enable Dependency Scan = true 
- Check critical severity count in log -> Ex -> Critical vulnerabilities: 6
- Open Checkmarx tab -> check critical severity count in graph and in report. 

Case 2
- Create new project with Enable Dependency Scan = true and Sca critical Threshold =1
- Check critical severity count in log -> Ex -> Critical vulnerabilities: 6
- Scan will fail with error -> SCA critical severity results are above threshold. Results: 6. Threshold: 1
- Open Checkmarx tab -> check critical severity count in graph and in report.Also, check threshold exceeded in red color


Case 3
- Create new project with Enable Dependency Scan = true and Sca critical Threshold =500
- Check critical severity count in log -> Ex -> Critical vulnerabilities: 6
- Scan will successfully completed
- Open Checkmarx tab -> check critical severity count in graph and in report.Also, check Threshold Compliant in green color

Case 4
- Create new project with Enable Dependency Scan = true and Sca critical Threshold =6
- Check critical severity count in log -> Ex -> Critical vulnerabilities: 6
- Scan will successfully completed
- Open Checkmarx tab -> check critical severity count in graph and in report.Also, check Threshold Compliant in green color

Case 5
- Create new project with Enable Dependency Scan = true and Sca critical Threshold =6, Sca High =3, Sca Medium=3, Sca Low = 3
- Check critical\high\medium\low severity count in logs
- Scan will fail with error 
	-> SCA critical severity results are above threshold. Results: 6. Threshold: 1
	-> SCA high severity results are above threshold. Results: 26. Threshold: 3
	-> SCA medium severity results are above threshold. Results: 15. Threshold: 3
- Open Checkmarx tab -> check critical\high\medium\low severity count in graph and in report.Also, check threshold exceeded in red color