### PR TITLE
[Azure Devops] Salesforce | 00209526 | "Error occurred while updating project tags: Bad request" on SCA scans with no tags set and SCA Resolver not enabled. 

### DIFF
--- a/src/dto/scanConfig.ts
+++ b/src/dto/scanConfig.ts
@@ -16,4 +16,5 @@ export interface ScanConfig {
     scaConfig?: ScaConfig;
     proxyConfig?: ProxyConfig;
     version?: string;
+    originName?: string;
 }

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -143,11 +143,11 @@ export class CxClient {
                 sastProxyConfig.proxyUrl = this.proxyConfig.sastProxyUrl != '' ? this.proxyConfig.sastProxyUrl : this.proxyConfig.proxyUrl;
                 sastProxyConfig.sastProxyUrl = '';
                 sastProxyConfig.scaProxyUrl = '';
-                this.httpClient = new HttpClient(baseUrl, this.config.cxOrigin, this.config.cxOriginUrl, this.log, sastProxyConfig, this.sastConfig.cacert_chainFilePath,this.config.version);
+                this.httpClient = new HttpClient(baseUrl,this.config.originName ? this.config.originName : this.config.cxOrigin, this.config.cxOriginUrl, this.log, sastProxyConfig, this.sastConfig.cacert_chainFilePath,this.config.version);
             }
             else 
             {
-                this.httpClient = new HttpClient(baseUrl, this.config.cxOrigin, this.config.cxOriginUrl, this.log, undefined, this.sastConfig.cacert_chainFilePath,this.config.version);
+                this.httpClient = new HttpClient(baseUrl, this.config.originName ? this.config.originName : this.config.cxOrigin, this.config.cxOriginUrl, this.log, undefined, this.sastConfig.cacert_chainFilePath,this.config.version);
             }
             await this.httpClient.getPacProxyResolve();
             await this.httpClient.login(this.sastConfig.username, this.sastConfig.password);
@@ -174,11 +174,11 @@ export class CxClient {
             scaProxyConfig.sastProxyUrl = '';
             scaProxyConfig.scaProxyUrl = '';
             this.log.info("Overriten URL "+this.config.proxyConfig.sastProxyUrl);
-            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.cxOrigin, this.config.cxOriginUrl,this.log, scaProxyConfig, this.scaConfig.cacert_chainFilePath,this.config.version);
+            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.originName ? this.config.originName : this.config.cxOrigin, this.config.cxOriginUrl,this.log, scaProxyConfig, this.scaConfig.cacert_chainFilePath,this.config.version);
         } 
         else 
         {
-            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.cxOrigin, this.config.cxOriginUrl,this.log, undefined, this.scaConfig.cacert_chainFilePath,this.config.version);
+            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.originName ? this.config.originName : this.config.cxOrigin, this.config.cxOriginUrl,this.log, undefined, this.scaConfig.cacert_chainFilePath,this.config.version);
         }
         await scaHttpClient.getPacProxyResolve();
         this.scaClient = new ScaClient(this.scaConfig, this.config.sourceLocation, scaHttpClient, this.log,scaProxyConfig, this.config);

--- a/src/services/clients/scaClient.ts
+++ b/src/services/clients/scaClient.ts
@@ -850,8 +850,8 @@ The Build Failed for the Following Reasons:
                 projectCustomTagObj = this.normalizeTags(this.config.projectCustomTags);
             let projectId = this.projectId;
             let path = ScaClient.PROJECTS + `/${projectId}`;
-            const teamName = this.config.scaSastTeam;
-            let teamNameArray: Array<string | undefined> = [teamName];
+            let teamName = this.config.scaSastTeam.trim();
+            let teamNameArray: Array<string | undefined> = (teamName != null && teamName != "" && teamName != '/') ? [teamName] : [];
             const request = {
                 name: this.scanConfig.projectName,
                 AssignedTeams: teamNameArray,


### PR DESCRIPTION
Test Case
- Run a new SCA scan with dependencySCA scan = true ,team = cxserver and add project custom field
- Wait till scan completed
 
**Test Case1** 
- Run again SCA scan with same project name ,team = blanck and  project custom field = blanck
**Expacted** - Bad Requst errir message will not display
 
**Test Case 2**
- Run again SCA scan with same project name ,team = Add Space and  project custom field = blanck
Expacted - Bad Requst errir message will not display
 
 
**Test Case 3**
- Run again SCA scan with same project name ,team = cxserver  and  project custom field = blanck
Expacted - Bad Requst errir message will not display