### PR TITLE
changes related to query result count without not exploitable

### DIFF
--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -682,9 +682,14 @@ Scan results location:  ${result.sastScanResultsLink}
             JSON.stringify({
                 name: query.$.name,
                 severity: query.$.Severity,
-                resultLength: query.Result.length
+                resultLength: this.getQueryResultCount(query.Result)
             })
         ).join(SEPARATOR);
+    }
+
+    private  static getQueryResultCount(Result: any[])
+    {
+        return  Result.length > 0 ? Result.filter( (queryResult )  =>  queryResult.$['state'] !== '1').length : 0;
     }
 
     private static getNewVulnerabilityCounts(scanResult: ScanResults, queries: any[]) {


### PR DESCRIPTION
**Test Case**
- Create new SAST project using ADO
- Run a scan
- Got SAST results
- Go to Sast web viewer and put some results as Not_Exploitable state
- Run same job from Jenkins

**Expected** 
- vulnerability count on ADO and SAST should be same