### PR TITLE
Q4 2024 integration branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkmarx/cx-common-js-client",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "description": "Client for interaction with Checkmarx products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/dto/scanConfig.ts
+++ b/src/dto/scanConfig.ts
@@ -16,4 +16,5 @@ export interface ScanConfig {
     scaConfig?: ScaConfig;
     proxyConfig?: ProxyConfig;
     version?: string;
+    originName?: string;
 }

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -143,11 +143,11 @@ export class CxClient {
                 sastProxyConfig.proxyUrl = this.proxyConfig.sastProxyUrl != '' ? this.proxyConfig.sastProxyUrl : this.proxyConfig.proxyUrl;
                 sastProxyConfig.sastProxyUrl = '';
                 sastProxyConfig.scaProxyUrl = '';
-                this.httpClient = new HttpClient(baseUrl, this.config.cxOrigin, this.config.cxOriginUrl, this.log, sastProxyConfig, this.sastConfig.cacert_chainFilePath,this.config.version);
+                this.httpClient = new HttpClient(baseUrl,this.config.originName ? this.config.originName : this.config.cxOrigin, this.config.cxOriginUrl, this.log, sastProxyConfig, this.sastConfig.cacert_chainFilePath,this.config.version);
             }
             else 
             {
-                this.httpClient = new HttpClient(baseUrl, this.config.cxOrigin, this.config.cxOriginUrl, this.log, undefined, this.sastConfig.cacert_chainFilePath,this.config.version);
+                this.httpClient = new HttpClient(baseUrl, this.config.originName ? this.config.originName : this.config.cxOrigin, this.config.cxOriginUrl, this.log, undefined, this.sastConfig.cacert_chainFilePath,this.config.version);
             }
             await this.httpClient.getPacProxyResolve();
             await this.httpClient.login(this.sastConfig.username, this.sastConfig.password);
@@ -174,11 +174,11 @@ export class CxClient {
             scaProxyConfig.sastProxyUrl = '';
             scaProxyConfig.scaProxyUrl = '';
             this.log.info("Overriten URL "+this.config.proxyConfig.sastProxyUrl);
-            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.cxOrigin, this.config.cxOriginUrl,this.log, scaProxyConfig, this.scaConfig.cacert_chainFilePath,this.config.version);
+            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.originName ? this.config.originName : this.config.cxOrigin, this.config.cxOriginUrl,this.log, scaProxyConfig, this.scaConfig.cacert_chainFilePath,this.config.version);
         } 
         else 
         {
-            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.cxOrigin, this.config.cxOriginUrl,this.log, undefined, this.scaConfig.cacert_chainFilePath,this.config.version);
+            scaHttpClient = new HttpClient(this.scaConfig.apiUrl, this.config.originName ? this.config.originName : this.config.cxOrigin, this.config.cxOriginUrl,this.log, undefined, this.scaConfig.cacert_chainFilePath,this.config.version);
         }
         await scaHttpClient.getPacProxyResolve();
         this.scaClient = new ScaClient(this.scaConfig, this.config.sourceLocation, scaHttpClient, this.log,scaProxyConfig, this.config);

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -682,9 +682,14 @@ Scan results location:  ${result.sastScanResultsLink}
             JSON.stringify({
                 name: query.$.name,
                 severity: query.$.Severity,
-                resultLength: query.Result.length
+                resultLength: this.getQueryResultCount(query.Result)
             })
         ).join(SEPARATOR);
+    }
+
+    private  static getQueryResultCount(Result: any[])
+    {
+        return  Result.length > 0 ? Result.filter( (queryResult )  =>  queryResult.$['state'] !== '1').length : 0;
     }
 
     private static getNewVulnerabilityCounts(scanResult: ScanResults, queries: any[]) {

--- a/src/services/clients/scaClient.ts
+++ b/src/services/clients/scaClient.ts
@@ -850,8 +850,8 @@ The Build Failed for the Following Reasons:
                 projectCustomTagObj = this.normalizeTags(this.config.projectCustomTags);
             let projectId = this.projectId;
             let path = ScaClient.PROJECTS + `/${projectId}`;
-            const teamName = this.config.scaSastTeam;
-            let teamNameArray: Array<string | undefined> = [teamName];
+            let teamName = this.config.scaSastTeam.trim();
+            let teamNameArray: Array<string | undefined> = (teamName != null && teamName != "" && teamName != '/') ? [teamName] : [];
             const request = {
                 name: this.scanConfig.projectName,
                 AssignedTeams: teamNameArray,


### PR DESCRIPTION
Following are the bug/ FR completed 
- PLUG-1871 - [ADO][CxCapG] Filter NE results in ADO plugin
- PLUG-1996 - "Error occurred while updating project tags: Bad request" on SCA scans with no tags set and SCA Resolver not enabled. Bug in version 2023.3.3 & Version 2024.2.5
- PLUG-1532 - [ADO] Add plugin name and the version in the user agent header
- 