### PR TITLE
'Vulnerable and outdated libraries' and 'no known vulnerability libraries' count is not displayed. 

### DIFF
--- a/src/dto/sca/scaReportResults.ts
+++ b/src/dto/sca/scaReportResults.ts
@@ -65,7 +65,7 @@ export class ScaReportResults {
         let sum: number;
         (this._packages || []).forEach(pckg => {
             if (pckg) {
-                sum = pckg.criticalVulnerabilityCount +
+                sum = pckg.criticalVulnerabilityCount != undefined ? pckg.criticalVulnerabilityCount : 0 +
                     pckg.highVulnerabilityCount +
                     pckg.mediumVulnerabilityCount +
                     pckg.lowVulnerabilityCount;


### PR DESCRIPTION
**Changes** 
Count for →  'Vulnerable and outdated libraries' and 'no known vulnerability libraries' is not displayed after running SCA scan for repo which has some vulnerabilities and outdated libraries.