### PR TITLE
[ADO] ADO SAST plugin always generates JSON file with no new SAST vulnerabilities

### DIFF
--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -629,10 +629,7 @@ export class CxClient {
         result.queryList = CxClient.toJsonQueries(result, doc.Query);
 
         //Find if there are any new vulnerabilities
-        if(this.sastConfig.failBuildForNewVulnerabilitiesEnabled)
-            CxClient.getNewVulnerabilityCounts(result, doc.Query);
-        
-        // TODO: PowerShell code also adds properties such as newHighCount, but they are not used in the UI.
+        CxClient.getNewVulnerabilityCounts(result, doc.Query);        
     }
 
 

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -629,7 +629,8 @@ export class CxClient {
         result.queryList = CxClient.toJsonQueries(result, doc.Query);
 
         //Find if there are any new vulnerabilities
-        CxClient.getNewVulnerabilityCounts(result, doc.Query);        
+        CxClient.getNewVulnerabilityCounts(result, doc.Query);  
+        // TODO: PowerShell code also adds properties such as newHighCount, but they are not used in the UI.
     }
 
 


### PR DESCRIPTION
**Test cases**
Note - Test below cases using ADO Cx Plugin UI or YML 

**Test Case 1**
- Create a new pipeline to run a new scan(use any git repo), example pipeline in "pipeline.txt" from the attached files in JIRA(change "CxSASTConn" to your connection)
- After successfully running, go to the pipeline and see the published json artifact and compare the counters.
- Confirm the results are new in the SAST UI.

**Expected Result**
The "new.." counters should be populated with the new vulnerabilities.

**Test Case 2**
- Run a new scan with same project name and settings
- After successfully running, go to the pipeline and see the published json artifact and compare the counters.
- Confirm the results are new in the SAST UI.

**Expected Result**
The "new.." counters should be zero.


**Test Case 3**
- Add one vulnerable file in repo 
- Run a new scan with same project name and settings
- After successfully running, go to the pipeline and see the published json artifact and compare the counters.
- Confirm the results are new in the SAST UI.

**Expected Result**
The "new.." counters should be be populated with the new vulnerabilities.

