### PR TITLE
SAST Fast scan

### DIFF
--- a/src/dto/api/engineConfiguration.ts
+++ b/src/dto/api/engineConfiguration.ts
@@ -1,0 +1,4 @@
+export interface engineConfiguration {
+    id: number,
+    name: string
+}

--- a/src/dto/api/engineConfigurationConstants.ts
+++ b/src/dto/api/engineConfigurationConstants.ts
@@ -1,0 +1,8 @@
+export const engineConfigurationConstants: Record<number, string> = {
+    0: "Project Default",
+    1: "Default Configuration",
+    2: "Japanese (Shift-JIS)",
+    3: "Korean",
+    5: "Multi-language Scan",
+    6: "Fast Scan",
+};

--- a/src/dto/sastConfig.ts
+++ b/src/dto/sastConfig.ts
@@ -29,7 +29,6 @@ export interface SastConfig {
     projectCustomFields: string;
     customFields: string;
     engineConfigurationId?: number;
-    engineConfigurationName?: string;
     postScanActionName: string;
     postScanActionId?: number;
     avoidDuplicateProjectScans:boolean;

--- a/src/dto/sastConfig.ts
+++ b/src/dto/sastConfig.ts
@@ -29,6 +29,7 @@ export interface SastConfig {
     projectCustomFields: string;
     customFields: string;
     engineConfigurationId?: number;
+    engineConfigurationName?: string;
     postScanActionName: string;
     postScanActionId?: number;
     avoidDuplicateProjectScans:boolean;

--- a/src/services/clients/cxClient.ts
+++ b/src/services/clients/cxClient.ts
@@ -65,10 +65,12 @@ export class CxClient {
                 let configId = await this.getEngineConfigurationId(this.sastConfig.engineConfigurationName);
                 if(configId == 0)
                 {
-                    if(this.sastConfig.engineConfigurationName == "Force Scan")
-                        this.log.error(`The Build Failed : SAST Engine Version 9.6.2 and lower version does not supports Force Scan (Source character encoding Configuration).`);
+                    result.buildFailed = true;
+                    if(this.sastConfig.engineConfigurationName == "Fast Scan")
+                        throw new Error("The Build Failed : SAST Engine Version 9.6.2 and lower version does not supports Force Scan (Source character encoding Configuration).");
                     else
-                        this.log.error(`The Build Failed : Selected source character encoding Configuration -> ${this.sastConfig.engineConfigurationName} not found.`);
+                        throw new Error("The Build Failed : Selected source character encoding Configuration -> ${this.sastConfig.engineConfigurationName} not found.");
+                    return Promise.reject(status); 
                 }
                 else
                     this.sastConfig.engineConfigurationId = configId;


### PR DESCRIPTION
**Note** - 
1. Test below cases with SAST 9.5, SAST 9.6 & SAST 9.7
2. Test below cases with ADO UI and YAML pipeline both

**Test Case 1**
- Create a SAST new project with **Configuration -> Default Configuration and Override Project Settings = false** 
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Default Configuration**


**Test Case 2**
- Create a SAST new project with **Configuration -> Japanese (Shift-JIS) and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Japanese (Shift-JIS)**


**Test Case 3**
- Create a SAST new project with **Configuration -> Korean and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Korean**

**Test Case 4**
- Create a SAST new project with **Configuration -> Multi-language Scan and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Multi-language Scan**

Test Case 5
- Create a SAST new project with **Configuration -> Fast Scan and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output for SAST Engine Version 9.6.3 and above -> Fast Scan**
**Expected Output for SAST Engine Version 9.6.2 and lower -> Pipeline will fail with error -> 
	The Build Failed : SAST Engine Version 9.6.2 and lower version does not supports Force Scan (Source character encoding Configuration)**


**Test Case 6**
- Open SAST DB and execute below query
	**select * from Config.CxEngineConfiguration**
 
	**update Config.CxEngineConfiguration set IsDefault = 0 where Id = 1**
	**update Config.CxEngineConfiguration set IsDefault = 1 where Id = 2**
	
**Updated Japanese (Shift-JIS) as default**
- Create a SAST new project with **Configuration -> Project Default and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Japanese (Shift-JIS)**

**Test Case 7**
- Run below test case with SAST engive version 9.6.3+
- Open SAST DB and execute below query
	**select * from Config.CxEngineConfiguration**
 
	**update Config.CxEngineConfiguration set IsDefault = 0 where Id = 1**
	**update Config.CxEngineConfiguration set IsDefault = 1 where Id = 2**
	
**Updated Japanese (Shift-JIS) as default**
- Create a SAST new project with **Configuration -> Fast Scan and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Fast Scan**
- Edit pipeline select **Configuration -> Project Default and Override Project Settings = false**
- Save and run pipeline with same project name
**Expected Output -> Fast Scan**
- Edit pipeline select **Configuration -> Korean and Override Project Settings = false**
- Save and run pipeline with same project name
**Expected Output -> Fast Scan**


**Test Case 8**
- Create a SAST new project with **Configuration -> Multi-language Scan and Override Project Settings = true**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Multi-language Scan**
- Edit pipeline select **Configuration -> Japanese (Shift-JIS) and Override Project Settings = true**
- Save and run pipeline with same project name
**Expected Output -> Japanese (Shift-JIS)**
- Edit pipeline select **Configuration -> Fast Scan** and **Override Project Settings = true**
- Save and run pipeline with same project name
**Expected Output -> Fast Scan**
- Edit pipeline select **Configuration -> Project Default and Override Project Settings = true**
- Save and run pipeline with same project name
**Expected Output -> Fast Scan**
